### PR TITLE
Remove secret key base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Remove SECRET_KEY_BASE since it has been moved to intercity-next repo (jvanbaarsen)
 - Symlink the Intercity Backup directory (See https://github.com/intercity/intercity-next/pull/42)
 - FROM_EMAIL env var, used for all the emails send out by IC.
 - Install Sendmail

--- a/samples/app.yml
+++ b/samples/app.yml
@@ -9,7 +9,6 @@ expose:
   - "2222:22" # fwd host port 2222 to container port 22 (ssh)
 env:
   LANG: en_US.UTF-8
-  SECRET_KEY_BASE: "secret_key_base"
   HOSTNAME: "intercity.example.com"
   FROM_EMAIL: "example@example.com"
 

--- a/templates/web.template.yml
+++ b/templates/web.template.yml
@@ -12,7 +12,6 @@ params:
 
 run:
   - exec: /usr/local/bin/ruby -e 'if ENV["HOSTNAME"] == "intercity.example.com"; puts "Aborting! Domain is not configured!"; exit 1; end'
-  - exec: /usr/local/bin/ruby -e 'if ENV["SECRET_KEY_BASE"] == "secret_key_base"; puts "Aborting! Secret key base is not configured!"; exit 1; end'
   - exec: /usr/local/bin/ruby -e 'if ENV["FROM_EMAIL"] == "example@example.com"; puts "Aborting! FROM_EMAIL is not configured"; exit 1; end'
   - file:
       path: /etc/runit/1.d/ensure-web-nginx-read


### PR DESCRIPTION
Since the generation of the secret key base has been moved to the intercity main
repo on app boot, it is no longer required to set this in the app.yml
