### PR TITLE
Allow Intercity to run behind HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .vagrant/
 containers/*
 shared/*
+shared/ssl/*.crt
+shared/ssl/*.key
+!shared/ssl/
 cids/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+* Add support for running Intercity behind HTTPS
+
 ## [0.3.0] - 2016-05-27
 * Symlink the Intercity Backup directory (See https://github.com/intercity/intercity-next/pull/42)
 * FROM_EMAIL env var, used for all the emails send out by IC.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@ BOX_NAME = ENV["BOX_NAME"] || "bento/ubuntu-14.04"
 BOX_MEMORY = ENV["BOX_MEMORY"] || 2048
 BOX_IP = ENV["BOX_IP"] || "10.0.0.4"
 FORWARDED_PORT = (ENV["FORWARDED_PORT"] || '8081').to_i
+FORWARDED_SSL_PORT = (ENV["FORWARDED_SSL_PORT"] || '8443').to_i
 
 Vagrant.configure(2) do |config|
   config.vm.box = BOX_NAME
@@ -16,6 +17,8 @@ Vagrant.configure(2) do |config|
 
   config.vm.define :docker, primary: true do |config|
     config.vm.network :forwarded_port, guest: 80, host: FORWARDED_PORT
+    config.vm.network :forwarded_port, guest: 443, host: FORWARDED_SSL_PORT
+
     config.vm.network :private_network, ip: BOX_IP
     config.vm.provision "shell", inline: <<-EOF
       set -e

--- a/samples/app.yml
+++ b/samples/app.yml
@@ -3,10 +3,12 @@ templates:
   - "templates/redis.template.yml"
   - "templates/sidekiq.template.yml"
   - "templates/web.template.yml"
+  #- "templates/web.ssl.template.yml"
 
 expose:
   - "80:80"   # fwd host port 80   to container port 80 (http)
   - "2222:22" # fwd host port 2222 to container port 22 (ssh)
+  #- "443:443" # fwd host port 443 to container port 443 (https)
 env:
   LANG: en_US.UTF-8
   HOSTNAME: "intercity.example.com"

--- a/templates/web.ssl.template.yml
+++ b/templates/web.ssl.template.yml
@@ -1,0 +1,38 @@
+run:
+  - exec:
+     cmd:
+       - "mkdir -p /shared/ssl/"
+       - "[ -e /shared/ssl/dhparams.pem ] || openssl dhparam -out /shared/ssl/dhparams.pem 2048"
+  - replace:
+     filename: "/etc/nginx/conf.d/intercity.conf"
+     from: /server.+{/
+     to: |
+       server {
+         listen 80;
+         rewrite ^ https://$$ENV_HOSTNAME$request_uri? permanent;
+       }
+       server {
+  - replace:
+     hook: ssl
+     filename: "/etc/nginx/conf.d/intercity.conf"
+     from: /listen 80;\s+gzip on;/m
+     to: |
+       listen 443 ssl;
+       ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+       ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
+       ssl_prefer_server_ciphers on;
+
+       ssl_certificate /shared/ssl/ssl.crt;
+       ssl_certificate_key /shared/ssl/ssl.key;
+       ssl_dhparam /shared/ssl/dhparams.pem;
+
+       ssl_session_timeout 1d;
+       ssl_session_cache shared:SSL:1m;
+
+       add_header Strict-Transport-Security 'max-age=31536000'; # remember the certificate for a year and automatically connect to HTTPS for this domain
+
+       gzip on;
+
+       if ($http_host != $$ENV_HOSTNAME) {
+          rewrite (.*) https://$$ENV_HOSTNAME$1 permanent;
+       }


### PR DESCRIPTION
This is currently done without any documentation. Let's first test this
ourselves, if the feature works properly I will document this in Intercity
itself.
