### PR TITLE
Added lets encrypt support for Intercity itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ shared/ssl/*.crt
 shared/ssl/*.key
 !shared/ssl/
 cids/*
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-* Add support for running Intercity behind HTTPS
+* Add support for running Intercity behind HTTPS (jvanbaarsen)
+* Add support for Letsencrypt based HTTPS (jvanbaarsen)
 
 ## [0.3.0] - 2016-05-27
 * Symlink the Intercity Backup directory (See https://github.com/intercity/intercity-next/pull/42)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,8 @@ Vagrant.configure(2) do |config|
       apt-get -y install ruby
       wget -qO- https://get.docker.com/ | sh
 
-      cp -r /vagrant /var/intercity
+      mkdir /var/intercity
+      rsync -r /vagrant /var/intercity
     EOF
   end
 end

--- a/samples/app.yml
+++ b/samples/app.yml
@@ -4,11 +4,12 @@ templates:
   - "templates/sidekiq.template.yml"
   - "templates/web.template.yml"
   #- "templates/web.ssl.template.yml"
+  #- "templates/web.letsencryp.ssl.template.yml"
 
 expose:
   - "80:80"   # fwd host port 80   to container port 80 (http)
   - "2222:22" # fwd host port 2222 to container port 22 (ssh)
-  #- "443:443" # fwd host port 443 to container port 443 (https)
+  - "443:443" # fwd host port 443 to container port 443 (https)
 env:
   LANG: en_US.UTF-8
   HOSTNAME: "intercity.example.com"
@@ -20,6 +21,8 @@ env:
   #SMTP_PASSWORD: pa$$word               # (optional, WARNING the char '#' in pw can cause problems!)
   #SMTP_ENABLE_START_TLS: true           # (optional, default true)
   #SMTP_DOMAIN:                          # (optional, If not provided we use the HOSTNAME)
+
+  #LETSENCRYPT_ACCOUNT_EMAIL: "youremail"
 
 params:
   # Which Git revision should container use?

--- a/templates/web.letsencrypt.ssl.template.yml
+++ b/templates/web.letsencrypt.ssl.template.yml
@@ -1,0 +1,58 @@
+env:
+  LETSENCRYPT_DIR: "/shared/letsencrypt"
+
+hooks:
+  after_ssl:
+    - exec:
+       cmd:
+         - if [ -z "$LETSENCRYPT_ACCOUNT_EMAIL" ]; then echo "LETSENCRYPT_ACCOUNT_EMAIL ENV variable is required and has not been set."; exit 1; fi
+         - /bin/bash -c "if [[ ! \"$LETSENCRYPT_ACCOUNT_EMAIL\" =~ ([^@]+)@([^\.]+) ]]; then echo \"LETSENCRYPT_ACCOUNT_EMAIL is not a valid email address\"; exit 1; fi"
+
+    - exec:
+       cmd:
+         - apt-get install -y netcat
+         - cd /root && git clone https://github.com/Neilpang/acme.sh.git && cd /root/acme.sh && git reset --hard 8d5618c44a2ab973aa7eb243db740e22c742b809
+         - touch /var/spool/cron/crontabs/root
+         - install -d -m 0755 -g root -o root $LETSENCRYPT_DIR
+         - cd /root/acme.sh && LE_WORKING_DIR="${LETSENCRYPT_DIR}" ./acme.sh --install
+
+    - file:
+       path: /etc/runit/1.d/letsencrypt
+       chmod: "+x"
+       contents: |
+          #!/bin/bash
+          LE_WORKING_DIR="${LETSENCRYPT_DIR}" $$ENV_LETSENCRYPT_DIR/acme.sh --issue -d $$ENV_HOSTNAME -k 4096 --standalone
+
+          if [ ! "$(cd $$ENV_LETSENCRYPT_DIR/$$ENV_HOSTNAME && openssl verify -CAfile ca.cer fullchain.cer | grep "OK")" ]; then
+            # Try to issue the cert again if something goes wrong
+            LE_WORKING_DIR="${LETSENCRYPT_DIR}" $$ENV_LETSENCRYPT_DIR/acme.sh --issue -d $$ENV_HOSTNAME -k 4096 --standalone --force
+          fi
+
+          LE_WORKING_DIR="${LETSENCRYPT_DIR}" $$ENV_LETSENCRYPT_DIR/acme.sh --installcert -d $$ENV_HOSTNAME --fullchainpath /shared/ssl/$$ENV_HOSTNAME.cer --keypath /shared/ssl/$$ENV_HOSTNAME.key --reloadcmd "sv reload nginx"
+          # After the initial install, switch to Webroot plugin
+          LE_WORKING_DIR="${LETSENCRYPT_DIR}" $$ENV_LETSENCRYPT_DIR/acme.sh _setopt $$ENV_LETSENCRYPT_DIR/$$ENV_HOSTNAME/$$ENV_HOSTNAME.conf "Le_Webroot" "=" "/var/www/intercity/public"
+
+    - replace:
+       filename: "/etc/nginx/conf.d/intercity.conf"
+       from: /ssl_certificate.+/
+       to: |
+         ssl_certificate /shared/ssl/$$ENV_HOSTNAME.cer;
+
+    - replace:
+       filename: /shared/letsencrypt/account.conf
+       from: /#ACCOUNT_EMAIL=.+/
+       to: |
+         ACCOUNT_EMAIL=$$ENV_LETSENCRYPT_ACCOUNT_EMAIL
+
+    - replace:
+       filename: "/etc/nginx/conf.d/intercity.conf"
+       from: /ssl_certificate_key.+/
+       to: |
+         ssl_certificate_key /shared/ssl/$$ENV_HOSTNAME.key;
+
+    - replace:
+       filename: "/etc/nginx/conf.d/intercity.conf"
+       from: /add_header.+/
+       to: |
+         # remember the certificate for 80 days and automatically connect to HTTPS for this domain
+         add_header Strict-Transport-Security 'max-age=6912000';


### PR DESCRIPTION
Now you can run your Intercity instance behind a Letsencrypt issued cert

This PR adds a way to request a LetsEncrypt cert when you run `./launcher rebuild app`. That way you can have free ssl certs.

We archieve this by making use of the acme.sh client (https://github.com/Neilpang/acme.sh). This client takes care of the requesting part, and the authorisation part.

The authorisation is required by LetsEncrypt, since it needs an endpoint to which it can check if a certain file is present. (The DNS validation we normally use).

The acme.sh is configured in such a way that it will use the /public/ folder of our app, that way you don't need to bring IC down when you need to request a cert.
